### PR TITLE
Fix usage of package name variable in paths.

### DIFF
--- a/CorshamScience.CodeStyle.CSharp.CodeOnly.template.props
+++ b/CorshamScience.CodeStyle.CSharp.CodeOnly.template.props
@@ -5,9 +5,9 @@
     <PackageVersion>#.#.#</PackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <CodeAnalysisRuleSetLocation Condition=" '$(NuGetPackageRoot)' != '' ">$(NuGetPackageRoot)$(PackageName)\#.#.#</CodeAnalysisRuleSetLocation>
-    <CodeAnalysisRuleSetLocation Condition=" '$(CodeAnalysisRuleSetLocation)' == '' and '$(SolutionDir)' != '' ">$(SolutionDir)packages\$(PackageName).#.#.#</CodeAnalysisRuleSetLocation>
-    <CodeAnalysisRuleSetLocation Condition=" '$(CodeAnalysisRuleSetLocation)' == '' ">$([System.IO.Path]::GetDirectoryName($(MSBuildProjectDirectory)))\packages\$(PackageName).#.#.#</CodeAnalysisRuleSetLocation>
+    <CodeAnalysisRuleSetLocation Condition=" '$(NuGetPackageRoot)' != '' ">$(NuGetPackageRoot)corshamscience.codestyle.csharp.codeonly\#.#.#</CodeAnalysisRuleSetLocation>
+    <CodeAnalysisRuleSetLocation Condition=" '$(CodeAnalysisRuleSetLocation)' == '' and '$(SolutionDir)' != '' ">$(SolutionDir)packages\corshamscience.codestyle.csharp.codeonly.#.#.#</CodeAnalysisRuleSetLocation>
+    <CodeAnalysisRuleSetLocation Condition=" '$(CodeAnalysisRuleSetLocation)' == '' ">$([System.IO.Path]::GetDirectoryName($(MSBuildProjectDirectory)))\packages\corshamscience.codestyle.csharp.codeonly.#.#.#</CodeAnalysisRuleSetLocation>
   </PropertyGroup>
   <PropertyGroup>
       <CodeAnalysisRuleSet>$(CodeAnalysisRuleSetLocation)\CorshamScience.CodeStyle.CSharp.CodeOnly.ruleset</CodeAnalysisRuleSet>


### PR DESCRIPTION
Modern versions of nuget / dotnet restore check out packages with lowercase folder names. References to $(PackageName) were producing camel-case in paths, which does not work on a case-sensitive filesystem (linux docker containers for example).